### PR TITLE
Slide separator dictionary now serves mkd markdown

### DIFF
--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -5,9 +5,10 @@ if !exists('g:presenting_vim_using')
 endif
 
 if !exists('g:presenting_slide_separators')
-    " the separators define the new page transition for diffrent filetypes
+    " the separators define the new page transition for different filetypes
     let g:presenting_slide_separators = {
           \ 'markdown': '\v(^|\n)\ze#+',
+          \ 'mkd': '\v(^|\n)\ze#+',
           \ 'org': '\v(^|\n)#-{4,}',
           \ 'rst': '\v(^|\n)\~{4,}',
           \ }


### PR DESCRIPTION
Since Plastic Boy's Vim Markdown plugin (and few others) work with
filetype `mkd`, they set up filetype so on following events:
- buffer read
- buffer new

Both causes the slide dictionary to return "no such key" since it has
"markdown" key, not "mkd".

Stemms from PR#7,
