### PR TITLE
Add support for Go slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Use [pathogen][3] or [vundle][4] to install presenting.vim.
 Simply write your presentation in your favorite markup language. Every slide
 is separated by a markup language specific marker.
 
-| Filetype | Slide Separator |
-| -------- | --------------- |
-| markdown | `# heading`     |
-| rst      | `~~~~`          |
-| orgmode  | `#----`         |
+|   Filetype   | Slide Separator |
+| ------------ | --------------- |
+| markdown     | `# heading`     |
+| rst          | `~~~~`          |
+| orgmode      | `#----`         |
+| GoLang slide | `* title`       |
+
 
 These can be overridden or extended by setting `b:presenting_slide_separator`
 for your preferred filetype in your `.vimrc`. For example, set the `.rst` slide

--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -42,6 +42,7 @@ Every slide is separated by a markup language specific marker:
  markdown       |  # heading
  rst            |  ~~~~
  orgmode        |  #----
+ GoLang slide   |  * heading
 <
 
 When you want to start presenting execute: >
@@ -55,6 +56,7 @@ Also, take a look at the presenting.vim examples:
  * PresentingExample.markdown
  * PresentingExample.rst
  * PresentingExample.org
+ * PresentingExample.slide
 
 ------------------------------------------------------------------------------
 INLINE CODE BLOCKS~

--- a/examples/PresentingDemo.slide
+++ b/examples/PresentingDemo.slide
@@ -1,0 +1,38 @@
+presenting.vim
+
+           *presenting.vim*
+
+          a presentation tool
+
+                for vim
+
+
+* Usage
+
+Each heading is a separate slide!
+
+Start presenting:
+
+ :PresentingStart
+
+
+Navigation:
+
+- n - next slide
+- p - previous slide
+- q - quit
+
+* The End
+
+
+
+*Thanks!*
+
+* After the End
+
+    "nothing to see here,
+    move along..."
+
+<!--
+vim:tw=40:ft=slide:
+-->

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -4,6 +4,7 @@ au FileType markdown let s:presenting_slide_separator = '\v(^|\n)\ze#+'
 au FileType mkd      let s:presenting_slide_separator = '\v(^|\n)\ze#+'
 au FileType org      let s:presenting_slide_separator = '\v(^|\n)#-{4,}'
 au FileType rst      let s:presenting_slide_separator = '\v(^|\n)\~{4,}'
+au FileType slide    let s:presenting_slide_separator = '\v(^|\n)\ze\*'
 
 if !exists('g:presenting_vim_using')
   let g:presenting_vim_using = 0


### PR DESCRIPTION
**Note:** Vim doesn't automatically assert that a `.slide` file has a file type `slide`