### PR TITLE
Custom statusline

### DIFF
--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -94,6 +94,24 @@ Add your own/customize the current ones: >
 <
 where '----' is the separator.
 
+------------------------------------------------------------------------------
+                                                       *presenting_statusline*
+This option allows you to customize the format of the statusline for the
+presentation buffer. See |statusline| for available fields.
+
+The following variables are available for use in this option:
+
+variable                         meaning~
+`b:presenting_page_current`        The current page number (starting from 1)
+`b:presenting_page_total`          Total number of pages in the slide
+
+Default: >
+  :let g:presenting_statusline =
+    \ '%{b:presenting_page_current}/%{b:presenting_page_total}'
+<
+Set the statusline to display cursor position: >
+  :let g:presenting_statusline = '%l, %c'
+<
 ==============================================================================
 ISSUES                                                     *presenting-issues*
 

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -10,6 +10,11 @@ if !exists('g:presenting_vim_using')
   let g:presenting_vim_using = 0
 endif
 
+if !exists('g:presenting_statusline')
+  let g:presenting_statusline =
+    \ '%{b:presenting_page_current}/%{b:presenting_page_total}'
+endif
+
 " Main logic / start the presentation {{{
 function! s:Start()
   if g:presenting_vim_using == 1
@@ -39,7 +44,7 @@ function! s:Start()
   tabedit _SLIDE_
   call s:ShowPage(0)
   let &filetype=s:filetype
-  setlocal statusline=%<
+  call s:UpdateStatusLine()
 
   " commands for the navigation
   command! -buffer PresentingNext call s:NextPage()
@@ -84,7 +89,7 @@ function! s:ShowPage(page_no)
   setlocal nocursorcolumn
   setlocal nocursorline
   setlocal cmdheight=1
-  setlocal statusline=%<
+  call s:UpdateStatusLine()
 
   " move cursor to the top
   execute ":normal! gg"
@@ -110,6 +115,13 @@ function! s:Exit()
     bdelete! _SLIDE_
   endif
 endfunction
+
+function! s:UpdateStatusLine()
+  let b:presenting_page_current = s:page_number + 1
+  let b:presenting_page_total = len(s:pages)
+  let &l:statusline = g:presenting_statusline
+endfunction
+
 " Functions for Navigation }}}
 
 " Parsing {{{


### PR DESCRIPTION
I added an option `g:presenting_statusline` to customize the statusline in the presentation buffer. With this option, the user can display useful information in the statusline like:

```vim
let g:presenting_statusline = '%l, %c'
```

To make the state of the presentation available to the statusline, I set the following variables in the buffer:

 variable                   | meaning
----------------------------|--------------------------------------------
 `b:presenting_page_current | The current page index (starting from 1)
 `b:presenting_page_total   | Total number of pages in the presentation

The user can then make the statusline display the format `Page: <current>/<total>` by:

```vim
let g:presenting_statusline = 'Page: %{b:presenting_page_current}/%{b:presenting_page_total}'
```
