### PR TITLE
Don't clobber the unnamed register when changing page

### DIFF
--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -76,7 +76,7 @@ function! s:ShowPage(page_no)
   " replace content of buffer with the next page
   setlocal noreadonly
   setlocal modifiable
-  execute ":normal! G$vggd"
+  %delete _
   call append(0, s:pages[s:page_number])
 
   " some options for the buffer


### PR DESCRIPTION
Presenting.vim uses the command `G$vggd` to clear the content of the slide buffer. This clobbers the unnamed register (") with the content of the previous page. Here's the steps to show the effect:

1. Open a markdown file
2. Yank the first line (`yy`)
3. Open the slide buffer (`:PresentingStart`)
4. Switch to the next page (`n`)
5. Close the slide buffer (`q`)
6. Paste (`p`)

The pasted content is not the previously yanked line, but the entire content of the first slide page.

I first replaced the command with `G$vgg"_d` to discard the deleted content. Then, I realized that this command can be replaced with `:%delete _`, which is easier to read.
