### PR TITLE
Add top margin option. Set options to wrap text. Fix doc.

### DIFF
--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -1,13 +1,13 @@
 *presenting.vim* *presenting.vim.txt* *presenting.txt* *presenting*
 A simple tool for presenting slides in Vim based on text files.
-
-                                   o                     o
-   _   ,_    _   ,   _   _  _  _|_     _  _    __,           _  _  _
- |/ \_/  |  |/  / \_|/  / |/ |  |  |  / |/ |  /  |  |  |_|  / |/ |/ |
- |__/    |_/|__/ \/ |__/  |  |_/|_/|_/  |  |_/\_/|/o \/  |_/  |  |  |_/
-/|                                              /|
-\|                                              \|
-
+>
+                                    o                     o
+    _   ,_    _   ,   _   _  _  _|_     _  _    __,           _  _  _
+  |/ \_/  |  |/  / \_|/  / |/ |  |  |  / |/ |  /  |  |  |_|  / |/ |/ |
+  |__/    |_/|__/ \/ |__/  |  |_/|_/|_/  |  |_/\_/|/o \/  |_/  |  |  |_/
+ /|                                              /|
+ \|                                              \|
+<
 
 Version: 0.1.0
 

--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -84,15 +84,16 @@ In the presentation mode there are the following mapping:
 CONFIGURATION                                       *presenting-configuration*
 
                                                  *presenting_slide_separators*
-This option defines the 'filetype-->slide separator' mapping and allows you
-to edit the current ones and add new ones.
-List the existing ones: >
-  :echo g:presenting_slide_separators
+This option overrides the default regular expression that specifies the slide
+separators, or defines a separator for filetypes not supported by default.
+
+Customize a supported filetype: >
+  au FileType rst let b:presenting_slide_separator = '\v(^|\n)\~{4,}'
 <
-Add your own/customize the current ones: >
-  :let g:presenting_slide_separators['my_filetype']='----'
+Add your own filetype: >
+  au FileType my_filetype let b:presenting_slide_separator = '----'
 <
-where '----' is the separator.
+  where '----' is the separator.
 
 ------------------------------------------------------------------------------
                                                        *presenting_statusline*

--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -113,6 +113,14 @@ Default: >
 Set the statusline to display cursor position: >
   :let g:presenting_statusline = '%l, %c'
 <
+------------------------------------------------------------------------------
+                                                       *presenting_top_margin*
+This option lets you define the number of blank lines to insert above each
+slide. Default: 0
+>
+  :let g:presenting_top_margin = 2
+<
+
 ==============================================================================
 ISSUES                                                     *presenting-issues*
 

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -85,6 +85,7 @@ function! s:ShowPage(page_no)
   silent %delete _
   call append(0, s:pages[s:page_number])
   call append(0, map(range(1,g:presenting_top_margin), '""'))
+  execute ":normal! gg"
   call append(line('$'), map(range(1,winheight('%')-(line('w$')-line('w0')+1)), '""'))
 
   " some options for the buffer

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -15,6 +15,10 @@ if !exists('g:presenting_statusline')
     \ '%{b:presenting_page_current}/%{b:presenting_page_total}'
 endif
 
+if !exists('g:presenting_top_margin')
+  let g:presenting_top_margin = 0
+endif
+
 " Main logic / start the presentation {{{
 function! s:Start()
   if g:presenting_vim_using == 1
@@ -80,6 +84,8 @@ function! s:ShowPage(page_no)
   " avoid "--No lines in buffer--" msg by using silent
   silent %delete _
   call append(0, s:pages[s:page_number])
+  call append(0, map(range(1,g:presenting_top_margin), '""'))
+  call append(line('$'), map(range(1,winheight('%')-(line('w$')-line('w0')+1)), '""'))
 
   " some options for the buffer
   setlocal buftype=nofile

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -98,6 +98,10 @@ function! s:ShowPage(page_no)
   setlocal norelativenumber
   setlocal noswapfile
   setlocal readonly
+  setlocal wrap
+  setlocal linebreak
+  setlocal breakindent
+  setlocal nolist
   call s:UpdateStatusLine()
 
   " move cursor to the top


### PR DESCRIPTION
The changes are pretty well documented in the commit messages. In summary:

* Updated the documentation to remove obsolete reference to dictionary
* Fixed formatting of the plugin's name in the help doc.
* Added an option to insert a specified number of blank lines above each slide.
* Appended blank lines after each slide to push the ~ lines off the window.
* Set 4 vim options to enable wrapping of text.