### PR TITLE
README.md: fix links to .rst and .org examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Once presenting, slide navigation is accomplished via these keys:
 For examples of presenting.vim presentations, see:
 
   * [PresentingExample.markdown](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.markdown)
-  * [PresentingExample.rst](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.org)
-  * [PresentingExample.org](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.rst)
+  * [PresentingExample.rst](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.rst)
+  * [PresentingExample.org](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.org)
   * [PresentingExample.slide](https://github.com/sotte/presenting.vim/blob/master/examples/PresentingDemo.slide)
 
 Of course you can configure the slide separators.


### PR DESCRIPTION
links to rst and org examples were reversed