### PR TITLE
Allow multiple presentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ When you want to start presenting, execute
 :PresentingStart
 ```
 
+It is possible to have multiple presentations running at the same time. Just
+run the command in each source document, and each slide show will be
+displayed in its own tab.
+
 Once presenting, slide navigation is accomplished via these keys:
 
 | Key | Action         |

--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -45,9 +45,12 @@ Every slide is separated by a markup language specific marker:
  GoLang slide   |  * heading
 <
 
-When you want to start presenting execute: >
+When you want to start presenting, execute: >
   :PresentingStart
 <
+It is possible to have multiple presentations running at the same time. Just
+run the command in each source document, and each slide show will be
+displayed in its own tab.
 
 You can navigate to the next slide (n), the previous slide (p) or quit (q)
 the presentation.

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -1,10 +1,10 @@
 " presenting.vim - presentation for vim
 
-au FileType markdown let s:presenting_slide_separator = '\v(^|\n)\ze#+'
-au FileType mkd      let s:presenting_slide_separator = '\v(^|\n)\ze#+'
-au FileType org      let s:presenting_slide_separator = '\v(^|\n)#-{4,}'
-au FileType rst      let s:presenting_slide_separator = '\v(^|\n)\~{4,}'
-au FileType slide    let s:presenting_slide_separator = '\v(^|\n)\ze\*'
+au FileType markdown let b:presenting_slide_separator_default = '\v(^|\n)\ze#+'
+au FileType mkd      let b:presenting_slide_separator_default = '\v(^|\n)\ze#+'
+au FileType org      let b:presenting_slide_separator_default = '\v(^|\n)#-{4,}'
+au FileType rst      let b:presenting_slide_separator_default = '\v(^|\n)\~{4,}'
+au FileType slide    let b:presenting_slide_separator_default = '\v(^|\n)\ze\*'
 
 if !exists('g:presenting_statusline')
   let g:presenting_statusline =
@@ -18,8 +18,8 @@ endif
 " Main logic / start the presentation {{{
 function! s:Start()
   " make sure we can parse the current filetype
-  if !exists('b:presenting_slide_separator') && !exists('s:presenting_slide_separator')
   let l:filetype = &filetype
+  if !exists('b:presenting_slide_separator') && !exists('b:presenting_slide_separator_default')
     echom "set b:presenting_slide_separator for \"" . l:filetype . "\" filetype to enable Presenting.vim"
     return
   endif
@@ -118,7 +118,7 @@ endfunction
 
 " Parsing {{{
 function! s:Parse()
-  let l:sep = exists('b:presenting_slide_separator') ? b:presenting_slide_separator : s:presenting_slide_separator
+  let l:sep = exists('b:presenting_slide_separator') ? b:presenting_slide_separator : b:presenting_slide_separator_default
   return map(split(join(getline(1, '$'), "\n"), l:sep), 'split(v:val, "\n")')
 endfunction
 " }}}

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -38,6 +38,19 @@ function! s:Start()
   let b:page_number = 0
   let b:max_page_number = len(b:pages) - 1
 
+  " some options for the buffer
+  setlocal buftype=nofile
+  setlocal cmdheight=1
+  setlocal nocursorcolumn nocursorline
+  setlocal nofoldenable
+  setlocal nonumber norelativenumber
+  setlocal noswapfile
+  setlocal wrap
+  setlocal linebreak
+  setlocal breakindent
+  setlocal nolist
+  let &filetype=l:filetype
+
   call s:ShowPage(0)
   call s:UpdateStatusLine()
 
@@ -64,30 +77,15 @@ function! s:ShowPage(page_no)
   let b:page_number = a:page_no
 
   " replace content of buffer with the next page
-  setlocal noreadonly
-  setlocal modifiable
+  setlocal noreadonly modifiable
   " avoid "--No lines in buffer--" msg by using silent
   silent %delete _
   call append(0, b:pages[b:page_number])
   call append(0, map(range(1,g:presenting_top_margin), '""'))
   execute ":normal! gg"
   call append(line('$'), map(range(1,winheight('%')-(line('w$')-line('w0')+1)), '""'))
+  setlocal readonly nomodifiable
 
-  " some options for the buffer
-  setlocal buftype=nofile
-  setlocal cmdheight=1
-  setlocal nocursorcolumn
-  setlocal nocursorline
-  setlocal nofoldenable
-  setlocal nomodifiable
-  setlocal nonumber
-  setlocal norelativenumber
-  setlocal noswapfile
-  setlocal readonly
-  setlocal wrap
-  setlocal linebreak
-  setlocal breakindent
-  setlocal nolist
   call s:UpdateStatusLine()
 
   " move cursor to the top

--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -15,7 +15,7 @@ if !exists('g:presenting_top_margin')
   let g:presenting_top_margin = 0
 endif
 
-" Main logic / start the presentation {{{
+" Main logic / start the presentation {{{1
 function! s:Start()
   " make sure we can parse the current filetype
   let l:filetype = &filetype
@@ -67,9 +67,8 @@ endfunction
 
 command! StartPresenting call s:Start()
 command! PresentingStart call s:Start()
-" }}}
 
-" Functions for Navigation {{{
+" Functions for Navigation {{{1
 function! s:ShowPage(page_no)
   if a:page_no < 0 || a:page_no >= len(b:pages)
     return
@@ -112,12 +111,10 @@ function! s:UpdateStatusLine()
   let &l:statusline = g:presenting_statusline
 endfunction
 
-" Functions for Navigation }}}
-
-" Parsing {{{
+" Parsing {{{1
 function! s:Parse()
   let l:sep = exists('b:presenting_slide_separator') ? b:presenting_slide_separator : b:presenting_slide_separator_default
   return map(split(join(getline(1, '$'), "\n"), l:sep), 'split(v:val, "\n")')
 endfunction
 " }}}
-" vim:ts=2:sw=2:expandtab
+" vim:ts=2:sw=2:expandtab:foldmethod=marker


### PR DESCRIPTION
This pull request allows the user to run multiple presentations at the same time, in separate tabs, of course. The most significant change here is the move of variables from script level (`s:....`) scope to buffer level (`b:...`). This keeps all relevant data contained to the buffer in which the show is being presented, and is a good move whether or not a user presents multiple slide shows.

The ability to specify custom slide separators remains unchanged.