### PR TITLE
Code cleanup and minor improvements

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -40,14 +40,14 @@ function! markdown#format(text, last_line, state)
     if l:state.table == []
       let l:state.table = [
         \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '┏', ''), '|\s*$', '┓', ''), '|', '┳', 'g'), '[^┏┓┳]', '━', 'g'),
-        \ substitute(a:text, '|', '┃', 'g') . 'TH'
+        \ substitute(a:text, '|', '┃', 'g')
       \ ]
     elseif a:text =~? '\s*|\(-\+|\)\+$'
       let l:state.table += [
         \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '┣', ''), '|\s*$', '┫', ''), '|', '╋', 'g'), '-', '━', 'g')
       \ ]
     else
-      let l:state.table += [substitute(a:text, '|', '┃', 'g') . 'TR']
+      let l:state.table += [substitute(a:text, '|', '┃', 'g') ]
     endif
 
 
@@ -133,7 +133,9 @@ endfunction
 
 function! s:FinishTable(text)
   let l:text = extend(a:text, [ substitute( substitute( substitute(a:text[0], '┏', '┗', ''), '┓', '┛', ''), '┳', '┻', 'g') ] )
-  return s:Center(l:text, '')
+  let l:text = s:Center(l:text, '«tr»')
+  let l:text[1] = substitute(l:text[1], '^«tr»', '«th»', '')
+  return l:text
 endfunction
 
 " vim:ts=2:sw=2:expandtab

--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -87,11 +87,11 @@ function! markdown#format(text, last_line, state)
     let level = strchars(matchstr(a:text, '^#\+'))
     let font = level == 1 ? g:presenting_font_large : g:presenting_font_small
     let figlet = split(system('figlet -w '.winwidth(0).' -f '.font.' '.shellescape(substitute(a:text,'^#\+s*','',''))), "\n")
-    let new_text += s:Center(figlet, '#'.level)
+    let new_text += s:Center(figlet, '«h'.level.'»')
 
   " Headings - Centered Normal Text for ####
   elseif a:text =~? '^####[^#]'
-    let new_text += s:Center([substitute(a:text,'^####\s*','','')], '#4')
+    let new_text += s:Center([substitute(a:text,'^####\s*','','')], '«h4»')
 
 
   " Quote Blocks - Wrap and Left Border

--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -39,38 +39,35 @@ function! markdown#format(text, last_line, state)
   elseif a:text =~? '\s*|\([^|]\+|\)\+$'
     if l:state.table == []
       let l:state.table = [
-        \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '┌', ''), '|\s*$', '┐', ''), '|', '┬', 'g'), '[^┌┐┬]', '─', 'g'),
-        \ substitute(a:text, '|', '│', 'g') . 'TH'
+        \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '┏', ''), '|\s*$', '┓', ''), '|', '┳', 'g'), '[^┏┓┳]', '━', 'g'),
+        \ substitute(a:text, '|', '┃', 'g') . 'TH'
       \ ]
     elseif a:text =~? '\s*|\(-\+|\)\+$'
       let l:state.table += [
-        \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '├', ''), '|\s*$', '┤', ''), '|', '┼', 'g'), '-', '─', 'g')
+        \ substitute(substitute(substitute(substitute(a:text, '^\s*|', '┣', ''), '|\s*$', '┫', ''), '|', '╋', 'g'), '-', '━', 'g')
       \ ]
     else
-      let l:state.table += [substitute(a:text, '|', '│', 'g') . 'TR']
+      let l:state.table += [substitute(a:text, '|', '┃', 'g') . 'TR']
     endif
 
 
   " Code Blocks - Indent. Precede and follow with horzontal line
   elseif a:text =~? '^\s*```'
     let l:state.code = !l:state.code
-    let new_text += ['    '.repeat('━', winwidth(0)-8)]
+    let new_text += ['    '.repeat(l:state.code ? '▄' : '▀', winwidth(0)-8)]
 
   elseif l:state.code
     let new_text += ['    '.a:text]
 
 
   " Checkboxes - Replace with Unicode squares
-  elseif a:text =~? '^[*-] \[ \]'
-    let new_text += [substitute(a:text,  '^[*-] \[ \]', '□', '')]
-
-  elseif a:text =~? '^[*-] \[x\]'
-    let new_text += [substitute(a:text,  '^[*-] \[x\]', '■', '')]
+  elseif a:text =~? '^[*-] \[[x ]\]'
+    let new_text += [substitute(substitute(a:text, '^[*-] \[ \]', '□', ''), '^[*-] \[x\]', '■', '')]
 
 
   " Bullet Lists - Replace with Unicode bullet
   elseif a:text =~? '^\s*[*-]'
-    let new_text += [substitute(a:text, '^\s*\zs[*-] ', '∙ ', '')]
+    let new_text += [substitute(a:text, '^\s*\zs[*-] ', '• ', '')]
 
 
   " Numbered Lists - Renumber, with indentation
@@ -102,10 +99,10 @@ function! markdown#format(text, last_line, state)
     let l:text = substitute(a:text, '^\s*>\s*', '', '')
     while strchars(l:text) > winwidth(0) - 8
       let s = strridx(strcharpart(l:text,0,winwidth(0)-10),' ')
-      let new_text += ['  ┃ '.strcharpart(l:text,0,s)]
+      let new_text += ['  ▐ '.strcharpart(l:text,0,s)]
       let l:text = strcharpart(l:text,s+1)
     endwhile
-    let new_text += ['  ┃ '.l:text]
+    let new_text += ['  ▐ '.l:text]
 
 
   " Return text as is.
@@ -135,7 +132,7 @@ function! s:Center(text, prefix)
 endfunction
 
 function! s:FinishTable(text)
-  let l:text = extend(a:text, [ substitute( substitute( substitute(a:text[0], '┌', '└', ''), '┐', '┘', ''), '┬', '┴', 'g') ] )
+  let l:text = extend(a:text, [ substitute( substitute( substitute(a:text[0], '┏', '┗', ''), '┓', '┛', ''), '┳', '┻', 'g') ] )
   return s:Center(l:text, '')
 endfunction
 

--- a/examples/PresentingDemo.markdown
+++ b/examples/PresentingDemo.markdown
@@ -70,7 +70,7 @@ Numbers are recalculated and incremented as you'd expect.
 
 ## Unordered
 
-Bullets are rendered with a Unicode bullet operator.
+Bullets are rendered with a Unicode bullet.
 
 - milk
 * bread

--- a/syntax/presenting_markdown.vim
+++ b/syntax/presenting_markdown.vim
@@ -2,11 +2,11 @@ runtime! syntax/markdown.vim
 
 setlocal conceallevel=3 concealcursor=nvic
 
-syntax match presentingHeadingDelimiter /^#[1-4]/ conceal
-syntax match presentingH1 /^#1.*/ contains=presentingHeadingDelimiter
-syntax match presentingH2 /^#2.*/ contains=presentingHeadingDelimiter
-syntax match presentingH3 /^#3.*/ contains=presentingHeadingDelimiter
-syntax match presentingH4 /^#4.*/ contains=presentingHeadingDelimiter
+syntax match presentingHeadingMarker /^«h[1-4]»/ conceal
+syntax match presentingH1 /^«h1».*/ contains=presentingHeadingMarker
+syntax match presentingH2 /^«h2».*/ contains=presentingHeadingMarker
+syntax match presentingH3 /^«h3».*/ contains=presentingHeadingMarker
+syntax match presentingH4 /^«h4».*/ contains=presentingHeadingMarker
 
 syntax match presentingOrderedListMarker /^\s*\d\+\./
 syntax match presentingListMarker /^\s*•/

--- a/syntax/presenting_markdown.vim
+++ b/syntax/presenting_markdown.vim
@@ -7,34 +7,29 @@ syntax match presentingH1 /^«h1».*/ contains=presentingHeadingMarker
 syntax match presentingH2 /^«h2».*/ contains=presentingHeadingMarker
 syntax match presentingH3 /^«h3».*/ contains=presentingHeadingMarker
 syntax match presentingH4 /^«h4».*/ contains=presentingHeadingMarker
+highlight default link presentingH1 markdownH1
+highlight default link presentingH2 markdownH2
+highlight default link presentingH3 markdownH3
+highlight default link presentingH4 markdownH4
 
 syntax match presentingOrderedListMarker /^\s*\d\+\./
 syntax match presentingListMarker /^\s*•/
 syntax match presentingCheckboxMarker /^\s*[■□]/
+highlight default link presentingOrderedListMarker markdownOrderedListMarker
+highlight default link presentingListMarker markdownListMarker
+highlight default link presentingCheckboxMarker markdownListMarker
 
 syntax match presentingCodeDelimiter /[▄▀]/ containedin=markdownCodeBlock
+highlight default link presentingCodeDelimiter markdownCodeDelimiter
 
 syntax match presentingBlockQuote /▐/
+highlight default link presentingBlockQuote markdownBlockquote
 
 syntax match presentingTableEdges /[┃━┏┓┗┛┳┻┣╋┫]/ containedin=markdownCodeBlock
 syntax match presentingTableHeaderMarker /^«th»/ conceal
 syntax match presentingTableRowMarker /^«tr»/ conceal
 syntax match presentingTableHeader /^«th».*$/ contains=presentingTableEdges,presentingTableHeaderMarker
 syntax match presentingTableRow /^«tr».*$/ contains=presentingTableEdges,presentingTableRowMarker
-
-highlight default link presentingH1 markdownH1
-highlight default link presentingH2 markdownH2
-highlight default link presentingH3 markdownH3
-highlight default link presentingH4 markdownH4
-
-highlight default link presentingOrderedListMarker markdownOrderedListMarker
-highlight default link presentingListMarker markdownListMarker
-highlight default link presentingCheckboxMarker markdownListMarker
-
-highlight default link presentingCodeDelimiter markdownCodeDelimiter
-
-highlight default link presentingBlockQuote markdownBlockquote
-
 highlight default link presentingTableEdges markdownRule
 highlight default link presentingTableHeader markdownH1
 highlight default link presentingTableRow Normal

--- a/syntax/presenting_markdown.vim
+++ b/syntax/presenting_markdown.vim
@@ -17,10 +17,10 @@ syntax match presentingCodeDelimiter /[▄▀]/ containedin=markdownCodeBlock
 syntax match presentingBlockQuote /▐/
 
 syntax match presentingTableEdges /[┃━┏┓┗┛┳┻┣╋┫]/ containedin=markdownCodeBlock
-syntax match presentingTableHeader /^.*TH$/ contains=presentingTableEdges
-syntax match presentingTableRow /^.*TR$/ contains=presentingTableEdges
-syntax match presentingTableHeaderMarker /TH$/ containedin=presentingTableHeader conceal
-syntax match presentingTableRowMarker /TR$/ containedin=presentingTableRow conceal
+syntax match presentingTableHeaderMarker /^«th»/ conceal
+syntax match presentingTableRowMarker /^«tr»/ conceal
+syntax match presentingTableHeader /^«th».*$/ contains=presentingTableEdges,presentingTableHeaderMarker
+syntax match presentingTableRow /^«tr».*$/ contains=presentingTableEdges,presentingTableRowMarker
 
 highlight default link presentingH1 markdownH1
 highlight default link presentingH2 markdownH2

--- a/syntax/presenting_markdown.vim
+++ b/syntax/presenting_markdown.vim
@@ -7,12 +7,16 @@ syntax match presentingH1 /^#1.*/ contains=presentingHeadingDelimiter
 syntax match presentingH2 /^#2.*/ contains=presentingHeadingDelimiter
 syntax match presentingH3 /^#3.*/ contains=presentingHeadingDelimiter
 syntax match presentingH4 /^#4.*/ contains=presentingHeadingDelimiter
+
 syntax match presentingOrderedListMarker /^\s*\d\+\./
-syntax match presentingListMarker /^\s*∙/
+syntax match presentingListMarker /^\s*•/
 syntax match presentingCheckboxMarker /^\s*[■□]/
-syntax match presentingCodeDelimiter /━/ containedin=markdownCodeBlock
-syntax match presentingBlockQuote /┃/
-syntax match presentingTableEdges /[┌─┬┐│├┼┤└┴┘]/ containedin=markdownCodeBlock
+
+syntax match presentingCodeDelimiter /[▄▀]/ containedin=markdownCodeBlock
+
+syntax match presentingBlockQuote /▐/
+
+syntax match presentingTableEdges /[┃━┏┓┗┛┳┻┣╋┫]/ containedin=markdownCodeBlock
 syntax match presentingTableHeader /^.*TH$/ contains=presentingTableEdges
 syntax match presentingTableRow /^.*TR$/ contains=presentingTableEdges
 syntax match presentingTableHeaderMarker /TH$/ containedin=presentingTableHeader conceal
@@ -22,11 +26,15 @@ highlight default link presentingH1 markdownH1
 highlight default link presentingH2 markdownH2
 highlight default link presentingH3 markdownH3
 highlight default link presentingH4 markdownH4
+
 highlight default link presentingOrderedListMarker markdownOrderedListMarker
 highlight default link presentingListMarker markdownListMarker
 highlight default link presentingCheckboxMarker markdownListMarker
+
 highlight default link presentingCodeDelimiter markdownCodeDelimiter
+
 highlight default link presentingBlockQuote markdownBlockquote
+
 highlight default link presentingTableEdges markdownRule
 highlight default link presentingTableHeader markdownH1
 highlight default link presentingTableRow Normal


### PR DESCRIPTION
I noticed some irregularities when I used this on my new Windows machine, so I fixed them:

First were some font issues.
1. Some of the table's line characters were not displaying as intended.
1. The bullet character used for unordered lists was too small.
1. After fixing the tables, I needed to use different characters to border the code blocks and quote blocks.

The next thing wasn't Windows-specific. I had noticed it before, but decided to put off fixing it until now. The tables are slightly off-center because of the markers used for syntax highlighting. They were appended before centering the text, instead of being prepended after centering. I fixed that, and used better markers for both tables and headings.