### PR TITLE
Hide color column

### DIFF
--- a/plugin/presenting.vim
+++ b/plugin/presenting.vim
@@ -62,6 +62,7 @@ function! s:Start()
   setlocal breakindent
   setlocal nolist
   setlocal signcolumn=no
+  setlocal colorcolumn=
 
   if globpath(&rtp, 'syntax/presenting_'.l:filetype.'.vim') == ''
     let &filetype=l:filetype


### PR DESCRIPTION
Hide the color column when `:PresentingStart` is called in order to avoid seeing a **vertical line at the middle** of the presentation.