### PR TITLE
Fix checkbox implementation for md

### DIFF
--- a/autoload/markdown.vim
+++ b/autoload/markdown.vim
@@ -71,8 +71,10 @@ function! markdown#format(text, last_line, state)
 
 
   " Checkboxes - Replace with Unicode squares
-  elseif a:text =~? '^\s*[*-] \[[x\s]\]'
-    let new_text += [substitute(substitute(a:text, '^[*-] \[\s\]', '□', ''), '^[*-] \[x\]', '■', '')]
+  elseif a:text =~? '^\s*[*-] \[[ xX]\]'
+    let tmp = substitute(a:text, '[*-] \[ \]',    '□', '')
+    let tmp = substitute(tmp,    '[*-] \[[xX]\]', '■', '')
+    let new_text += [tmp]
 
 
   " Bullet Lists - Replace with Unicode bullet

--- a/examples/PresentingDemo.markdown
+++ b/examples/PresentingDemo.markdown
@@ -57,7 +57,10 @@ Lists can be ordered, unordered, or To Do list items. As a reminder, here is the
 - bulleted item
 
 - [ ] unchecked item
+  - [ ] unchecked sub-item
 - [x] checked item
+  - [x] checked sub-item
+- [X] checked item
 ```
 ## Ordered
 
@@ -83,7 +86,11 @@ Bullets are rendered with a Unicode bullet.
 Checkboxes are rendered with Unicode as either empty or filled squares.
 
 - [ ] Not done yet
+  - [ ] Task 1
+  - [ ] Task 2
 - [x] Done
+  - [x] Task 1
+  - [X] Task 2
 
 These are part of Github-flavored Markdown, not the official Markdown specification.
 


### PR DESCRIPTION
- Adjust the regex and split the long nested code lines.
- Adjust the md example.

Example:
```
- [ ] Not done yet
  - [ ] Task 1
  - [ ] Task 2
- [x] Done
  - [x] Task 1
  - [X] Task 2
```

Before this PR:
![image](https://user-images.githubusercontent.com/79138/120444654-1cbc4080-c388-11eb-8067-1a82df160cd8.png)


After this PR:
![image](https://user-images.githubusercontent.com/79138/120444464-ef6f9280-c387-11eb-8a5a-a69f4df85565.png)
